### PR TITLE
Fix unit test assertions for Win32 FAT filesystems.

### DIFF
--- a/t/Path.t
+++ b/t/Path.t
@@ -485,7 +485,11 @@ SKIP : {
         $mode = (stat($dir))[2];
         $octal_mode = S_IMODE($mode);
         $octal_input = sprintf "%04o", S_IMODE($input);
-        is($octal_mode,$input, "create a new directory with chmod $input ($octal_input)");
+        SKIP: {
+	    skip "permissions are not fully supported by the filesystem", 1
+                if (($^O eq 'MSWin32' || $^O eq 'cygwin') && ((Win32::FsType())[1] & 8) == 0);
+            is($octal_mode,$input, "create a new directory with chmod $input ($octal_input)");
+	}
         rmtree( $dir );
     }
 }


### PR DESCRIPTION
RT 121248: Windows FAT and VFAT filesystems do not support full
permissions. Skip the assertions that require this support.