### PR TITLE
Pull in the `old_style` logic in its own functions

### DIFF
--- a/lib/File/Path.pm
+++ b/lib/File/Path.pm
@@ -595,7 +595,7 @@ sub _rmtree {
             print "unlink $canon\n" if $data->{verbose};
 
             # delete all versions under VMS
-            for ( ; ; ) {
+            while () {
                 if ( unlink $root ) {
                     push @{ ${ $data->{result} } }, $root if $data->{result};
                 }


### PR DESCRIPTION
Centralizes the definition of what is old style in `__is_old_style` and simplify `mkpath` by pushing the old_style code in its own inner sub.

(this PR is part of the CPAN PR Challenge)