### PR TITLE
Set current user as an owner for parent directories

### DIFF
--- a/lib/File/Path.pm
+++ b/lib/File/Path.pm
@@ -94,6 +94,7 @@ sub mkpath {
         $paths = [$paths] unless UNIVERSAL::isa( $paths, 'ARRAY' );
         $data->{verbose} = $verbose;
         $data->{mode} = defined $mode ? $mode : oct '777';
+        $data->{owner} = $<;
     }
     else {
         my %args_permitted = map { $_ => 1 } ( qw|


### PR DESCRIPTION
The problem happens in a Docker container with mounted case-sensitive APFS when running `miniperl_top "-I../../lib" -MExtUtils::Command -e 'mkpath' -- ../../lib/auto/lib` as
```
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! ERROR: Can't create '../../lib/auto'
Do not have write permissions on '../../lib/auto'
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! 
```
where ../../lib/auto has root as an owner instead of the current user.

The PR should fix the issue by setting the owner for all created directories.